### PR TITLE
Add Commune MCP — hosted email infrastructure for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ _No entries yet_
 - **Offers:** Access to Jira and Confluence Cloud data
 - **Access:** OAuth authentication required, respects existing Atlassian permission controls
 
+#### [Commune MCP](https://github.com/commune-sh/commune-mcp)
+
+- **Offers:** Email infrastructure for AI agents — provision inboxes on demand, send and receive email, manage concurrent threads, custom domains, structured extraction on inbound mail, and SMS. Built for agents, not humans — no SMTP config, no Gmail wrappers.
+- **Access:** API key auth via `COMMUNE_API_KEY`. Install: `uvx commune-mcp`
+
 ### Media & Content
 
 _No entries yet_


### PR DESCRIPTION
Adding Commune MCP — it fits this list well since it's a fully hosted/remote MCP server (no local SMTP, no IMAP config, just an API key).

The main thing it does differently from other email tools: it treats email as agent infrastructure rather than a user interface. So you get programmatic inbox provisioning, real thread isolation across concurrent conversations, custom sending domains, and structured extraction on inbound mail. You're not automating someone's Gmail — you're giving the agent its own email identity.

Also supports SMS from the same server, which is handy for notification-style workflows where email feels too heavy.

Access: API key auth (`COMMUNE_API_KEY`), install via `uvx commune-mcp`.