### PR TITLE
Add CrashStory MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ _No entries yet_
 
 ### Data & Analytics
 
-_No entries yet_
+#### [CrashStory MCP](https://github.com/DavidMelamed/crashstory-mcp)
+
+- **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
+- **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
 ### Developer Tools
 


### PR DESCRIPTION
## Summary
- add CrashStory MCP under Data & Analytics
- include the public repo, hosted remote endpoint, and install docs URL

CrashStory MCP is a public hosted MCP server for Colorado crash data, attorney discovery, and AI-analyzed review intelligence.