### PR TITLE
Add Roundtable to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ _No entries yet_
 - **Offers:** Uses the popular open-source security scanner, [Semgrep](https://semgrep.dev), to scan code for vulnerabilities.
 - **Access:** A `streamable-http` endpoint is hosted at `https://mcp.semgrep.ai/mcp`. See [docs](https://github.com/semgrep/mcp) for more details.
 
+#### [Roundtable](https://roundtable.now)
+
+- **Offers:** Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs
+- **Access:** Streamable HTTP endpoint at `https://mcp.roundtable.now/mcp`. See [GitHub](https://github.com/sinaneshat/roundtable-dashboard) for more details
+
 ### Knowledge & Memory
 
 #### [Supermemory MCP](https://mcp.supermemory.ai/)


### PR DESCRIPTION
## Summary

Adds [Roundtable](https://roundtable.now) to the Developer Tools section.

Roundtable is a multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. It offers 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs.

- **Website:** https://roundtable.now
- **MCP Endpoint:** https://mcp.roundtable.now/mcp
- **Transport:** Streamable HTTP
- **GitHub:** https://github.com/sinaneshat/roundtable-dashboard