### PR TITLE
Add Frihet MCP Server to Payments & Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**23 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-23-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-10-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -203,6 +203,11 @@ _No entries yet_
 
 - **Offers:** Access to Square's APIs for payments, orders, inventory, and customer management
 - **Access:** OAuth authentication with your Square account required
+
+#### [Frihet MCP](https://frihet.io)
+
+- **Offers:** AI-native business management with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance. Manage your entire business operations through natural language
+- **Access:** Server available at `https://mcp.frihet.io/mcp` (Streamable HTTP). Also installable locally via npm: `npx @frihet/mcp-server`. See [docs](https://docs.frihet.io) for setup details
 
 ## Auto Counter
 


### PR DESCRIPTION
## Add Frihet MCP Server

Adding [Frihet MCP Server](https://github.com/Frihet-io/frihet-mcp) to the **Payments & Commerce** section.

**Frihet** is an AI-native business management platform with a hosted remote MCP server endpoint.

### Entry details

- **Service URL:** https://frihet.io
- **Remote endpoint:** `https://mcp.frihet.io/mcp` (Streamable HTTP)
- **npm:** `@frihet/mcp-server` (for local installation)
- **License:** MIT
- **Tools:** 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance
- **Docs:** https://docs.frihet.io

### Checklist

- [x] Service implements Model Context Protocol
- [x] Hosted/managed and accessible via URL endpoint (`https://mcp.frihet.io/mcp`)
- [x] Uses Streamable HTTP transport
- [x] Actively maintained
- [x] Has documentation (https://docs.frihet.io)
- [x] Added to one category only (Payments & Commerce)
- [x] Follows entry format from CONTRIBUTING.md
- [x] Updated MCP server count (23 -> 24)