### PR TITLE
Add WZRD Velocity Oracle hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ _No entries yet_
 - **Offers:** Cross-chain cryptocurrency swaps via the Chainflip decentralized exchange. Discover available assets, get swap quotes, execute simple or DCA swaps, and track swap progress across blockchains.
 - **Access:** Remote MCP server at `https://chainflip-broker.io/mcp` (Streamable HTTP). No authentication required. Optional API key for partner attribution.
 
+#### [WZRD Velocity Oracle](https://twzrd.xyz)
+
+- **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
+- **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
## Summary
- add WZRD Velocity Oracle to the Finance & Crypto section
- include the public Streamable HTTP endpoint and manifest for zero-config install

## Why it fits
WZRD is a hosted public MCP server with a stable URL endpoint. It offers real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling.

## Access
- MCP endpoint: `https://app.twzrd.xyz/api/mcp`
- Manifest: `https://twzrd.xyz/.well-known/mcp-server.json`
- Public reads require no auth.