### PR TITLE
feat: add Since Today commerce MCP servers (podcast, newsletter, recipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ _No entries yet_
 - **Offers:** Access to Square's APIs for payments, orders, inventory, and customer management
 - **Access:** OAuth authentication with your Square account required
 
+#### [Podcast Commerce MCP](https://github.com/teamsincetoday/podcast-commerce-mcp)
+
+- **Offers:** AI-powered extraction of affiliate products, sponsor mentions, and shoppable recommendations from podcast episodes. Includes cross-show product comparison and automated show notes generation.
+- **Access:** Free tier (200 calls/day, no API key required). Above that: $0.01/call via x402 payment middleware.
+
+#### [Newsletter Commerce MCP](https://github.com/teamsincetoday/newsletter-commerce-mcp)
+
+- **Offers:** AI-powered extraction of shoppable products and sponsor mentions from newsletter editions, with automated affiliate-ready product section generation.
+- **Access:** Free tier (200 calls/day, no API key required). Above that: $0.01/call via x402 payment middleware.
+
+#### [Recipe Commerce MCP](https://github.com/teamsincetoday/recipe-commerce-mcp)
+
+- **Offers:** AI-powered extraction of affiliate-ready product recommendations from recipe content — ingredients, kitchen tools, and equipment with sponsor analysis.
+- **Access:** Free tier (200 calls/day, no API key required). Above that: $0.01/call via x402 payment middleware.
+
 ### Finance & Crypto
 
 #### [Chainflip Broker](https://chainflip-broker.io)


### PR DESCRIPTION
Adding three remote MCP servers for content commerce intelligence to the Payments & Commerce section.

All three are live remote Streamable HTTP endpoints (Cloudflare Workers), MIT licensed, with free tier (200 calls/day, no API key required):

- **Podcast Commerce MCP**: https://podcast-commerce-mcp.sincetoday.workers.dev/mcp — Extracts affiliate products and sponsor mentions from podcast episodes
- **Newsletter Commerce MCP**: https://newsletter-commerce-mcp.sincetoday.workers.dev/mcp — Extracts shoppable products from newsletter editions  
- **Recipe Commerce MCP**: https://recipe-commerce-mcp.sincetoday.workers.dev/mcp — Extracts affiliate-ready products from recipe content