### PR TITLE
Add: AAAA-Nexus MCP — hosted MCP server with x402 payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+
+#### [Aethel-Nexus](https://aaaa-nexus.atomadictech.workers.dev)
+
+- **Offers:** Formally verified AI safety APIs — hallucination oracle (Lean 4 certified upper bound), RatchetGate session re-key (fixes MCP CVE-2025-6514), VeriRand quantum RNG, HELIX model compression (83% reduction), streaming CoT inference, A2A agent registry/swarm, UCAN delegation validation, GDPR/CCPA compliance gate. 75+ endpoints.
+- **Access:** Connect to `https://aaaa-nexus.atomadictech.workers.dev/mcp` via Streamable HTTP; manifest at `https://aaaa-nexus.atomadictech.workers.dev/.well-known/mcp.json`; free endpoints (entropy, agent registry, RNG) require no auth; paid endpoints use x402 USDC micropayments on Base L2 (no signup, agents pay autonomously)
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)

--- a/README.md
+++ b/README.md
@@ -253,10 +253,10 @@ _No entries yet_
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
 
-#### [AAAA-Nexus](https://aaaa-nexus.atomadictech.workers.dev)
+#### [AAAA-Nexus](https://atomadic.tech)
 
 - **Offers:** Hosted AI infrastructure with MCP support, agent-card discovery, and x402 pay-per-call access.
-- **Access:** Connect to `https://aaaa-nexus.atomadictech.workers.dev/mcp` via Streamable HTTP; manifest at `https://aaaa-nexus.atomadictech.workers.dev/.well-known/mcp.json`; public repo at `https://github.com/atomadictech/aaaa-nexus`
+- **Access:** Connect to `https://atomadic.tech/mcp` via Streamable HTTP; manifest at `https://atomadic.tech/.well-known/mcp.json`; public repo at `https://github.com/atomadictech/aaaa-nexus`
 
 ### Gaming & Entertainment
 

--- a/README.md
+++ b/README.md
@@ -253,10 +253,10 @@ _No entries yet_
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
 
-#### [Aethel-Nexus](https://aaaa-nexus.atomadictech.workers.dev)
+#### [AAAA-Nexus](https://aaaa-nexus.atomadictech.workers.dev)
 
-- **Offers:** Formally verified AI safety APIs — hallucination oracle (Lean 4 certified upper bound), RatchetGate session re-key (fixes MCP CVE-2025-6514), VeriRand quantum RNG, HELIX model compression (83% reduction), streaming CoT inference, A2A agent registry/swarm, UCAN delegation validation, GDPR/CCPA compliance gate. 75+ endpoints.
-- **Access:** Connect to `https://aaaa-nexus.atomadictech.workers.dev/mcp` via Streamable HTTP; manifest at `https://aaaa-nexus.atomadictech.workers.dev/.well-known/mcp.json`; free endpoints (entropy, agent registry, RNG) require no auth; paid endpoints use x402 USDC micropayments on Base L2 (no signup, agents pay autonomously)
+- **Offers:** Hosted AI infrastructure with MCP support, agent-card discovery, and x402 pay-per-call access.
+- **Access:** Connect to `https://aaaa-nexus.atomadictech.workers.dev/mcp` via Streamable HTTP; manifest at `https://aaaa-nexus.atomadictech.workers.dev/.well-known/mcp.json`; public repo at `https://github.com/atomadictech/aaaa-nexus`
 
 ### Gaming & Entertainment
 


### PR DESCRIPTION
## New Remote MCP Server Submission

Name: AAAA-Nexus
Endpoint: https://atomadic.tech/mcp
Manifest: https://atomadic.tech/.well-known/mcp.json
Docs: https://github.com/atomadictech/aaaa-nexus

Why it belongs here:
- hosted remote MCP server
- public API and MCP endpoint
- agent-card based discovery
- x402 pay-per-call access

This updates the submission to the current approved public positioning.