### PR TITLE
Add ZKProofport to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [ZKProofport](https://zkproofport.app)
+
+- **Offers:** Zero-knowledge proof generation for AI agent identity. Agents can prove Coinbase KYC, Country, Google OIDC, Workspace, or Microsoft 365 affiliation without revealing personal data. Server-side proving runs in AWS Nitro Enclave TEE on a trusted backend. Returns only nullifier hashes — no personal information leaves the proof circuit.
+- **Access:** Local MCP server `@zkproofport-ai/mcp` (`npm install -g @zkproofport-ai/mcp@latest`) calls remote TEE backend at `https://ai.zkproofport.app`. Pay-per-proof via x402 USDC on Base (~$0.05/proof). ERC-8004 registered (token #25331).
+- **Recognition:** Reference application [OpenStoa](https://github.com/zkproofport/openstoa) won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects).
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Adds **ZKProofport** to the **Finance & Crypto** section.

ZKProofport is a remote MCP server that lets AI agents generate zero-knowledge proofs of identity (Coinbase KYC, Country, Google OIDC, Workspace, MS 365) without revealing personal data. The local CLI `@zkproofport-ai/mcp` calls the remote TEE backend at `https://ai.zkproofport.app`.

**Why it fits this list:**
- **Hosted/cloud-deployed**: Server-side proof generation runs on AWS Nitro Enclave TEE
- **Public access**: x402 USDC pay-per-proof on Base (no API key, no signup)
- **Crypto-native**: Coinbase KYC verification is core functionality
- **ERC-8004 registered**: Token #25331 on Base Mainnet

**Production validation**: Reference application [OpenStoa](https://github.com/zkproofport/openstoa) won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects, 1500+ builders).