### PR TITLE
Add Not Human Search MCP to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ _No entries yet_
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
 
+#### [Not Human Search MCP](https://nothumansearch.ai/.well-known/mcp.json)
+
+- **Offers:** Search engine for AI agents — discover verified agent-first websites and APIs ranked by agentic readiness score (llms.txt, OpenAPI, ai-plugin, MCP, structured API). Query by keyword, category, or minimum score; submit new sites for indexing
+- **Access:** Public manifest at `https://nothumansearch.ai/.well-known/mcp.json` with four tools (`search`, `get_site`, `submit_site`, `stats`) backed by REST endpoints at `https://nothumansearch.ai/api/v1/*`; no API key required
+
 ### Communication & Collaboration
 
 #### [Asana MCP](https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server)


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) — a public remote MCP server for discovering verified agent-first websites and APIs, ranked by agentic readiness (llms.txt, OpenAPI, ai-plugin, MCP, structured API).

**Manifest:** https://nothumansearch.ai/.well-known/mcp.json
**Tools:** `search`, `get_site`, `submit_site`, `stats`
**API:** https://nothumansearch.ai/api/v1/* (REST, no API key required)

Fits under **Search & Data Extraction** alongside 402.bot — both focus on agent-accessible endpoint discovery.