### PR TITLE
Add OpenRegistry (Data & Analytics) — 27 national company registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ _No entries yet_
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
+#### [openregistry](https://openregistry.sophymarine.com)
+
+- **Offers:** Live official data from 27 national company registries (UK Companies House, France RNE, Germany Handelsregister, Italy InfoCamere, Spain BORME, Korea OpenDART, Canada CBCA, 10 US state registries, and more). Search companies, fetch profiles, list filings, retrieve officers, beneficial owners, charges, and raw filing documents (XHTML / PDF / XBRL / XML). Built for KYC / AML / due-diligence workflows. A platform by sophymarine.
+- **Access:** Remote MCP server at `https://openregistry.sophymarine.com/mcp` (Streamable HTTP, MCP spec 2025-06-18). Anonymous access works out of the box (20 req/min per IP, 3-country fan-out per 60s). OAuth 2.1 + Dynamic Client Registration (RFC 7591) raises limits for paid tiers — no API key to paste.
+
 ### Developer Tools
 
 #### [Linear MCP](https://linear.app/docs/mcp)


### PR DESCRIPTION
Adds [OpenRegistry](2) to the **Data & Analytics** section.

OpenRegistry is a hosted remote MCP server — a platform by Sophymarine — providing live, unmodified access to 27 national company registries (UK, France, Germany, Italy, Spain, Korea, Canada, 10 US states, and more). Tools cover company search, profile, filings, officers, beneficial ownership, charges, and raw document retrieval.

- **Endpoint:** `https://openregistry.sophymarine.com/mcp` (Streamable HTTP)
- **Auth:** Anonymous tier available (no API key). OAuth 2.1 + Dynamic Client Registration for paid tiers.
- **Also published on:** Official MCP Registry (`io.github.sophymarine/openregistry`), punkpeye/awesome-mcp-servers (PR #5117), Cline Marketplace (issue #1385).

## Live demo (updated 2026-04-19)

Ran the Cross-Border UBO Chain Walker on Revolut Ltd (UK Companies House 08804411) — in ~1.2 seconds Claude ran four live queries to UK Companies House and returned:
- The 2022-04-29 corporate restructure (individual PSC → group holdings on the same day)
- Chain endpoint at Revolut Group Holdings Ltd (12743269)
- Individual controller: Mr Nikolay Storonskiy, British, UK-resident, 25-50% shares + right to appoint directors
- Spelling variation preserved verbatim: "Storonsky" (2016 filing) vs "Storonskiy" (2020 filing) — Companies House never normalises names, neither do we. A "normalising" aggregator would hide this.

Every fact verifiable at https://find-and-update.company-information.service.gov.uk/company/08804411/persons-with-significant-control

## The 6 design pillars

1. **Live** — real-time queries at call-time
2. **Direct-to-government** — no aggregator
3. **Unmodified + source-linked** — registry's own field names and raw filing bytes preserved; identifiers resolve back to the government URL
4. **Zero-stale** — no cache we control can go stale
5. **Stable** — production-grade on CF Workers + warm per-jurisdiction workers
6. **Cross-border** — walk UK Ltd → LU SARL → KY LP → individual in one prompt