### PR TITLE
Add Whipscribe to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ _No entries yet_
 
 ### Media & Content
 
-_No entries yet_
+#### [Whipscribe](https://whipscribe.com)
+
+- **Offers:** Audio and video transcription. Transcribe from a URL (YouTube, podcast feeds, direct media links) or an uploaded file; returns `txt`, `json`, `srt`, `vtt`, or `docx` with optional speaker diarization and word-level timestamps. Free anonymous tier; paid tier with higher limits.
+- **Access:** Sign up at [whipscribe.com](https://whipscribe.com) for an API key, then configure the MCP endpoint in your client. Local install also available via `uvx whipscribe-mcp`.
 
 ### Payments & Commerce
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ _No entries yet_
 #### [Whipscribe](https://whipscribe.com)
 
 - **Offers:** Audio and video transcription. Transcribe from a URL (YouTube, podcast feeds, direct media links) or an uploaded file; returns `txt`, `json`, `srt`, `vtt`, or `docx` with optional speaker diarization and word-level timestamps. Free anonymous tier; paid tier with higher limits.
-- **Access:** Sign up at [whipscribe.com](https://whipscribe.com) for an API key, then configure the MCP endpoint in your client. Local install also available via `uvx whipscribe-mcp`.
+- **Access:** Sign up at [whipscribe.com](https://whipscribe.com) for an API key, then connect your MCP client to `https://whipscribe.com/mcp` with a Bearer token. Local install also available via `uvx whipscribe-mcp`.
 
 ### Payments & Commerce
 


### PR DESCRIPTION
Adds Whipscribe to Media & Content (first entry in that category).

**Fit against the contributing criteria:**
- MCP server: yes — implements the Model Context Protocol.
- Hosted/managed: yes — accessible via a URL endpoint; no user-side binary required.
- Network-accessible: yes.
- Actively maintained.
- Documentation: yes, at https://whipscribe.com and https://github.com/neugence/whipscribe-mcp.

**What it does:** Audio/video transcription via Whisper. Accepts a URL (YouTube, podcasts, direct media links) or uploaded file; returns txt/json/srt/vtt/docx with optional speaker diarization and word timestamps. Free anonymous tier plus paid tier.