### PR TITLE
Add EnigmAgent to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ _No entries yet_
 - **Offers:** Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs
 - **Access:** Streamable HTTP endpoint at `https://mcp.roundtable.now/mcp`. See [GitHub](https://github.com/sinaneshat/roundtable-dashboard) for more details
 
+- [EnigmAgent](https://enigmagent.dev) - Encrypted credential vault MCP. Resolves `{{PLACEHOLDER}}` API keys at runtime. Local vault, REST mode available.
+
 ### Knowledge & Memory
 
 #### [Supermemory MCP](https://mcp.supermemory.ai/)


### PR DESCRIPTION
Adds EnigmAgent to the Developer Tools section.

**EnigmAgent** — encrypted credential vault MCP server. Resolves `{{PLACEHOLDER}}` API keys at runtime. Supports both local vault mode and REST API mode.

GitHub: https://github.com/Agnuxo1/EnigmAgent | npm: `npx enigmagent-mcp`