### PR TITLE
Add Xquik remote MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**25 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-25-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -206,6 +206,11 @@ _No entries yet_
 
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
+
+#### [Xquik MCP](https://docs.xquik.com/mcp/overview)
+
+- **Offers:** X (Twitter) data extraction, account monitoring, write actions, webhooks, and SDK-backed API access through Xquik's hosted MCP server
+- **Access:** Streamable HTTP endpoint at `https://xquik.com/mcp` with API key or OAuth bearer authentication required
 
 ### Communication & Collaboration
 


### PR DESCRIPTION
## Summary

Adds Xquik MCP to the Search & Data Extraction category.

## Why it fits

- Xquik exposes a hosted Streamable HTTP MCP endpoint at `https://xquik.com/mcp`.
- It supports X (Twitter) data extraction, account monitoring, write actions, webhooks, and SDK-backed API access.
- Access uses API key or OAuth bearer authentication.

## Checks

- Verified `https://docs.xquik.com/mcp/overview` returns HTTP 200.
- Verified `https://xquik.com/mcp` responds to MCP-compatible OPTIONS with HTTP 204.
- Checked for existing Xquik entries and open duplicate issues/PRs before submitting.
- Ran `git diff --check`.
