### PR TITLE
Add NotFair under Marketing & CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ _No entries yet_
 - **Offers:** Build Tally forms using natural language through AI assistants. Create contact forms, surveys, and other form types with specific fields, validation, and customization options
 - **Access:** Server available at `https://api.tally.so/mcp` with API key authentication required (`Authorization: Bearer tly-xxxx`). Get your API key from your Tally account
 
+#### [NotFair](https://notfair.co)
+
+- **Offers:** Hosted Google Ads MCP server. Diagnose campaign performance (CPA, ROAS, search-term waste, quality scores, learning-phase status), recommend optimizations (bids, budgets, negative keywords, ad copy), and execute approved changes via the official Google Ads API with a built-in human-approval gate.
+- **Access:** Server available at `https://notfair.co/api/mcp/google_ads`. Sign up at [notfair.co](https://notfair.co) and add it as a custom connector in Claude (or any MCP client) — auth via NotFair sign-in flow. Free tier available (7 days unlimited, then 300 ops/month, no credit card).
+
 ### Search & Data Extraction
 
 #### [Apify Actors MCP](https://mcp.apify.com/)


### PR DESCRIPTION
Adding NotFair under Marketing & CRM. NotFair is a hosted Google Ads MCP server that lets Claude and other MCP clients connect to a Google Ads account, diagnose campaign performance (CPA, ROAS, search-term waste, quality scores, learning-phase status), recommend optimizations (bids, budgets, negative keywords, ad copy), and execute approved changes via the official Google Ads API with a built-in human-approval gate.

It's network-accessible at `https://notfair.co/api/mcp/google_ads` and auth is handled through NotFair's sign-in flow when you add it as a custom connector. Free tier available (7 days unlimited, then 300 ops/month) with no credit card required.

Followed the entry format in CONTRIBUTING.md and added at the bottom of the Marketing & CRM section. Happy to adjust if you'd prefer different wording or placement.