### PR TITLE
Add Packrift hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**36 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-36-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -239,6 +239,11 @@ _No entries yet_
 
 - **Offers:** Access to Square's APIs for payments, orders, inventory, and customer management
 - **Access:** OAuth authentication with your Square account required
+
+#### [Packrift MCP Server](https://packrift.com/pages/agents)
+
+- **Offers:** Packaging catalog search, pricing and inventory context, and cart URL creation for ecommerce packaging-supply workflows
+- **Access:** Remote MCP server at `https://mcp.packrift.com/mcp` (Streamable HTTP). No authentication required.
 
 ### Finance & Crypto
 


### PR DESCRIPTION
Adds Packrift's hosted MCP server under Payments & Commerce.\n\nPackrift exposes a remote Streamable HTTP MCP endpoint for packaging catalog search, pricing and inventory context, and cart URL creation for ecommerce packaging workflows.\n\nVerification:\n- Public repo: https://github.com/Packrift/packrift-mcp\n- Docs: https://packrift.com/pages/agents\n- Remote endpoint: https://mcp.packrift.com/mcp returned HTTP 200 text/event-stream during local check.\n\nI also ran the repo's counter script after adding the entry.