### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+
+#### [YIELD INTELLIGENCE](https://api.intuitek.ai/yield/mcp)
+
+- **Offers:** Passive income opportunity analysis with live US Treasury rates (T-bills, T-notes, T-bonds), portfolio yield calculator, and AI-powered income optimization. Tools: `analyze_yield_opportunities`, `optimize_income_portfolio`. No auth required.
+- **Auth:** None required
+- **Transports:** HTTP+SSE
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance category.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

This is a remote MCP server — no local installation needed, connect directly by URL.
