### PR TITLE
Add Doxa MCP to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ _No entries yet_
 - **Offers:** Scientific paper search with structured experimental data extracted from full-text studies
 - **Access:** Server available at `https://mcp.bgpt.pro/sse` (SSE) or `https://mcp.bgpt.pro/mcp` (Streamable HTTP). Also available via `npx bgpt-mcp`
 
+#### [Doxa MCP](https://doxa.app/mcp)
+
+- **Offers:** Christian encouragement and Bible lookup for any MCP client. Three tools grounded in the Berean Standard Bible (public domain): doxa_encourage, doxa_scripture (BSB verse lookup with deep links), and doxa_way_movement. Scripture, summoned.
+- **Access:** Free public streamable HTTP endpoint at `https://doxa.app/mcp/v1`. No authentication required for the free tier; bring your own licence (BYOL) via one header for unlimited use. See `https://doxa.app/mcp` for setup
+
 ### Communication & Collaboration
 
 #### [Asana MCP](https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server)


### PR DESCRIPTION
Adds Doxa MCP to the Search & Data Extraction section of README.md.

Doxa MCP is a free hosted, remote (streamable HTTP) Model Context Protocol server for Christian encouragement and Bible lookup, usable from Claude Desktop, Cursor, Cline, LibreChat, and any MCP client.

- Endpoint: https://doxa.app/mcp/v1
- Landing page: https://doxa.app/mcp
- Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema
- npm client: @thedoxaway/mcp-client

Three tools, all grounded in the Berean Standard Bible (public domain): doxa_encourage (Scripture-grounded encouragement), doxa_scripture (BSB verse lookup with deep links), doxa_way_movement (guidance through the Doxa Way).

Install snippet for the client config:

```json
{"mcpServers":{"doxa":{"command":"npx","args":["-y","mcp-remote","https://doxa.app/mcp/v1"]}}}
```

The free hosted tier needs no credentials; bring your own licence (one header) unlocks unlimited use. It is the only Christian MCP publishing a public 5/5 pass on the independent faith.tools Christian-AI safety rubric, including crisis handling.

The single entry was appended at the end of the Search & Data Extraction section, following the existing "#### [Name](url)" header plus "Offers" and "Access" bullet format used by neighbouring entries. Only README.md changed; the MCP_COUNT comment and shields.io badge numbers were left untouched.
