### PR TITLE
Add avots (hosted multi-model AI media + chat MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ See MindPal agents in action with:
 - **Offers:** Seamless workflow automation and AI tool integration with direct access to Pabbly Connect's suite of business management applications (including CRM, email, billing, forms, and more) via MCP. Enables AI assistants to execute workflow actions, add leads, send emails, fetch data, and more, directly from your Pabbly Connect workflows.
 - **Access:** In your Pabbly Connect workflow, use the "Add to MCP server" option for any action, configure your tool, and retrieve your unique MCP Server URL from [Pabbly Connect MCP Settings](https://connect.pabbly.com/v2/app/setting/mcp-server). Use this URL as your endpoint for AI clients (e.g., Claude Desktop, etc). See [setup instructions](https://forum.pabbly.com/threads/pabbly-connect-mcp-server-beta.28381/) for full details.
 
+#### [avots](https://mcp.avots.ai/)
+
+- **Offers:** Image, video, audio, face-swap, talking-avatar generation and chat across 300+ AI models (Claude, GPT, Gemini, DeepSeek, and more) from one balance, via a Streamable HTTP (MCP 2025-06-18) endpoint.
+- **Access:** Sign up at [avots.ai](https://avots.ai), mint an API key in Settings → Integrations, then connect `https://mcp.avots.ai/` with an `Authorization: Bearer av_mcp_…` header. Docs: [github.com/avotsai/avots-mcp](https://github.com/avotsai/avots-mcp)
+
 ### Cloud Platforms
 
 _No entries yet_


### PR DESCRIPTION
Adds **avots** under Aggregators & Integration Platforms.

- **Endpoint:** `https://mcp.avots.ai/` — Streamable HTTP (MCP 2025-06-18), API-key (Bearer) auth.
- **Offers:** image, video, audio, face-swap, talking-avatar generation and chat across 300+ AI models from one balance.
- **Docs:** https://github.com/avotsai/avots-mcp