### PR TITLE
feat: add The Stall to Finance & Crypto — 210 pay-per-call MCP tools (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [The Stall](https://the-stall.intuitek.ai/mcp)
+
+- **Offers:** 172 pay-per-call financial and market intelligence tools covering equities (price, fundamentals, earnings, options chain), crypto/DeFi (prices, whale radar, DEX quotes, stablecoin watch), macro (FOMC, treasury yields, IMF outlook), on-chain (EVM logs, wallet balance, ENS), alternative data (congressional trades, FEC donors, sanctions screening), and 20+ more verticals. Payments via x402 protocol (USDC on Base) — sub-cent per call, no subscription.
+- **Access:** Remote MCP at `https://the-stall.intuitek.ai/mcp` via Streamable HTTP. No API key required. x402-capable wallet needed for paid tools (e.g., Coinbase CDP); free tools available without payment.
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
## The Stall

Adds **The Stall** to the Finance & Crypto section — a remote MCP server with 210 pay-per-call financial and market intelligence tools.

### What it offers
- **Equities:** stock price, fundamentals, earnings surprises, analyst ratings, insider trades, options chain, short volume, Form 144 signals
- **Crypto/DeFi:** prices, DEX swap quotes, whale radar, protocol revenue, stablecoin watch, crypto fear & greed, twitter-intel
- **Macro:** FOMC tracker, treasury yields & auctions, IMF outlook, labor market, housing brief
- **On-chain:** EVM logs, wallet balance, ERC20 snapshot, token security, ENS lookup
- **Alternative data:** congressional trades, FEC donor intel, sanctions screening, Polymarket accuracy, cron-parser
- 185+ more data verticals, **210 tools total**

### Access
- Remote MCP endpoint: `https://the-stall.intuitek.ai/mcp`
- Transport: Streamable HTTP
- Auth: None required
- Payment: x402 protocol (USDC on Base) — sub-cent per call
- Free tools available without payment; paid tools need x402-capable wallet

git: d25c40a | version: v4.64.0 | caps: 210