### PR TITLE
Add BuyWhere MCP — remote product search for Singapore & SEA markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ _No entries yet_
 - **Offers:** Commerce capabilities for inventory management, payment processing, shipping tracking, and refund handling
 - **Access:** OAuth authentication with your PayPal account required
 
+#### [BuyWhere MCP](https://mcp.buywhere.ai/mcp)
+
+- **Offers:** Real-time product search and price comparison across 260K+ products from major Singapore and SEA merchants (Lazada, Shopee, Courts, FairPrice). Search by name, category, or price range and get live availability data.
+- **Access:** API key required — free self-serve registration at https://buywhere.ai/api-keys
+
 #### [Block (Square) MCP](https://developer.squareup.com/docs/mcp)
 
 - **Offers:** Access to Square's APIs for payments, orders, inventory, and customer management


### PR DESCRIPTION
## BuyWhere MCP

Adding BuyWhere to the Payments & Commerce section.

BuyWhere is a hosted remote MCP server providing real-time product search and price comparison for Singapore and Southeast Asia:

- **260K+ products** from Lazada, Shopee, Courts, FairPrice, and other major SEA merchants
- **Remote endpoint**: `https://mcp.buywhere.ai/mcp`
- **Authentication**: API key (free, instant at buywhere.ai/api-keys)
- Cross-merchant price comparison in a single query

GitHub: https://github.com/BuyWhere/buywhere-mcp