### PR TITLE
Add Prismix Status MCP to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ _No entries yet_
 - **Offers:** Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs
 - **Access:** Streamable HTTP endpoint at `https://mcp.roundtable.now/mcp`. See [GitHub](https://github.com/sinaneshat/roundtable-dashboard) for more details
 
+
+#### [Prismix Status MCP](https://prismix.dev/mcp-server)
+
+- **Offers:** Real-time status of 75+ AI services (OpenAI, Anthropic, Cursor, Groq, GitHub Copilot, and more) with live incident tracking. Lets Claude and other AI assistants answer "Is OpenAI down?" or "Which AI services are degraded?" with live data.
+- **Access:** Free, no authentication required. Streamable HTTP endpoint: `https://prismix.dev/api/v1/mcp`
+
 ### Knowledge & Memory
 
 #### [Supermemory MCP](https://mcp.supermemory.ai/)


### PR DESCRIPTION
Adds Prismix to the Developer Tools section.

Prismix is a hosted, remote MCP server that provides live AI service status data:

- **75+ AI services** monitored: OpenAI, Anthropic, Cursor, Groq, GitHub Copilot, and more
- **Two tools:** `check_ai_status` (filter by service name) and `list_ai_services` (enumerate all)
- **Free, no auth required** — Streamable HTTP transport, protocol `2024-11-05`
- **Use case:** Ask Claude "Is OpenAI down right now?" and get a live answer from the status snapshot

Entry format matches existing Developer Tools entries (Sentry, DeepWiki, GitMCP, Semgrep).

Live: https://prismix.dev/mcp-server
Endpoint: https://prismix.dev/api/v1/mcp