### PR TITLE
Add htmlbook under Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ _No entries yet_
 
 ### Media & Content
 
-_No entries yet_
+#### [htmlbook](https://htmlbook.io)
+
+- **Offers:** Publish AI-generated HTML & Markdown to a hosted, shareable, themed URL — an agent pushes a doc via MCP and htmlbook stores, versions, organizes, and publicly shares it as a permanent link.
+- **Access:** Sign in at [htmlbook.io](https://htmlbook.io), generate an API key in Settings (or connect via OAuth from Claude/Cursor), then add the MCP endpoint `https://htmlbook.io/api/mcp`.
 
 ### Payments & Commerce
 


### PR DESCRIPTION
Adds **htmlbook** under **Media & Content** (first entry in that category).

htmlbook is a hosted MCP server that lets an AI agent publish the HTML/Markdown it generates to a shareable, themed URL — it stores, versions, organizes, and publicly shares the doc.

- **Hosted/managed:** yes — endpoint `https://htmlbook.io/api/mcp` (Streamable HTTP), nothing to download/run.
- **Auth:** OAuth 2.1 (with dynamic client registration) or a static API key.
- **Docs:** https://htmlbook.io and https://github.com/Streamize-llc/htmlbook

Format follows CONTRIBUTING (`#### [name](url)` + Offers/Access).