### PR TITLE
Add AgentsCoin to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [AgentsCoin](https://agents-coin.com)
+
+- **Offers:** Give your AI agent its own money on a live EVM chain — create a wallet, claim coins from a faucet, send funds, and create/trade tokens. 9 tools total.
+- **Access:** Remote MCP server at `https://agents-coin.com/mcp` (Streamable HTTP). No authentication required.
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Adds **AgentsCoin** to the Finance & Crypto section.

AgentsCoin — give an AI agent its own money on a live EVM chain. 9 tools (wallet, faucet, send, create/trade tokens). It is a hosted/remote MCP reachable via a single URL (`https://agents-coin.com/mcp`, Streamable HTTP, no auth), matching this list's criterion of Hosted & Managed MCP Servers accessible via a URL endpoint.

- MCP server: https://github.com/axiosdevs/agentscoin-mcp (npm `agentscoin-mcp`, remote URL https://agents-coin.com/mcp)
- Claude Desktop extension (.mcpb): https://github.com/axiosdevs/agentscoin-claude-extension
- Site: https://agents-coin.com
