### PR TITLE
Add BuyWhere MCP server to Payments & Commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ _No entries yet_
 
 #### [Block (Square) MCP](https://developer.squareup.com/docs/mcp)
 
+#### [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp)
+
+- **Offers:** Real-time cross-border e-commerce product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee). MCP server for AI-powered shopping agents.
+- **Access:** Server available at `https://mcp.buywhere.ai` (Streamable HTTP). No authentication required for basic search. API key available for higher rate limits.
+
+#### [Block (Square) MCP](https://developer.squareup.com/docs/mcp)
+
 - **Offers:** Access to Square's APIs for payments, orders, inventory, and customer management
 - **Access:** OAuth authentication with your Square account required
 


### PR DESCRIPTION
## Summary

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the Payments & Commerce section.

**BuyWhere** is a remote MCP server for real-time cross-border e-commerce product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee, etc.).

## Why it fits

- **Payments & Commerce**: BuyWhere provides commerce-related capabilities — product search, price comparison, and deal discovery across major e-commerce platforms.
- **Remote MCP server**: Available at `https://mcp.buywhere.ai` via Streamable HTTP transport.
- **Already listed on 17+ directories** including PulseMCP, mcp.so, Smithery, Glama, and the official MCP Registry.
- **Open source**: https://github.com/BuyWhere/buywhere-mcp

## Entry format

```markdown
#### [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp)

- **Offers:** Real-time cross-border e-commerce product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee). MCP server for AI-powered shopping agents.
- **Access:** Server available at `https://mcp.buywhere.ai` (Streamable HTTP). No authentication required for basic search. API key available for higher rate limits.
```