### PR TITLE
Add LLM Pulse hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated list of remote Model Context Protocol (MCP) Servers accessible via a simple URL endpoint.
 
-🚀 <!-- MCP_COUNT -->**24 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
+🚀 <!-- MCP_COUNT -->**36 MCP servers**<!-- /MCP_COUNT --> 🔥 ready for instant integration!
 
 <div align="center">
 
-![MCP Servers](https://img.shields.io/badge/MCP%20Servers-24-brightgreen?style=for-the-badge&logo=server&logoColor=white)
+![MCP Servers](https://img.shields.io/badge/MCP%20Servers-36-brightgreen?style=for-the-badge&logo=server&logoColor=white)
 ![Categories](https://img.shields.io/badge/Categories-11-blue?style=for-the-badge&logo=folder&logoColor=white)
 ![Zero Setup](https://img.shields.io/badge/Zero%20Setup-✅-success?style=for-the-badge&logo=rocket&logoColor=white)
 ![Instant Integration](https://img.shields.io/badge/Instant%20Integration-⚡-yellow?style=for-the-badge&logo=zap&logoColor=white)
@@ -128,6 +128,11 @@ _No entries yet_
 
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
+
+#### [LLM Pulse](https://llmpulse.ai/features/mcp)
+
+- **Offers:** AI search visibility analytics for brand mentions, citations, sentiment, share of voice, tracked prompts, recommendations, and AI-referred traffic
+- **Access:** Hosted Streamable HTTP endpoint at `https://api.llmpulse.ai/api/v1/mcp` with OAuth 2.1 authentication. Public documentation is available at `https://llmpulse.ai/features/mcp`
 
 ### Developer Tools
 


### PR DESCRIPTION
## Summary
Adds LLM Pulse to the Data & Analytics section as a hosted remote MCP server.

## Why it fits
- Implements MCP over a hosted Streamable HTTP endpoint
- Provides public documentation at https://llmpulse.ai/features/mcp
- Exposes AI search visibility analytics, including brand mentions, citations, sentiment, share of voice, tracked prompts, recommendations, and AI-referred traffic
- Uses OAuth 2.1 authentication with protected-resource metadata at https://api.llmpulse.ai/.well-known/oauth-protected-resource/api/v1/mcp

## Maintenance
- Public metadata repository: https://github.com/LLM-Pulse/llmpulse-mcp