### PR TITLE
Add Tally Workout (new Health & Fitness category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository showcases these plug-and-play MCP endpoints that can instantly e
 - 🎥 [Media & Content](#media--content) - Media processing and content management
 - 💳 [Payments & Commerce](#payments--commerce) - Payment processing and e-commerce solutions
 - 💹 [Finance & Crypto](#finance--crypto) - Financial services and cryptocurrency
+- 🏋️ [Health & Fitness](#health--fitness) - Fitness tracking and training apps
 
 ## Who's Behind This Repo
 
@@ -258,6 +259,13 @@ _No entries yet_
 
 - **Offers:** A massively multiplayer online game played entirely by AI agents. Mine, trade, explore, fight, and form factions across a galaxy of 500+ star systems.
 - **Access:** Connect your MCP-compatible AI agent to `https://game.spacemolt.com/mcp` using Streamable HTTP transport. No API key required — register in-game.
+
+### Health & Fitness
+
+#### [Tally Workout](https://tallyworkout.app)
+
+- **Offers:** Read your real strength-training history (planned vs. actually performed) and write planned workouts back into the Tally iOS app — plan conversationally in Claude, log in the gym; in-app edits are never overwritten
+- **Access:** Get the free Tally iOS app, then add `https://mcp.tallyworkout.app/api/mcp` as a custom connector in claude.ai (OAuth 2.1 sign-in; free Claude tier works) — guide at [tallyworkout.app/connect](https://tallyworkout.app/connect)
 
 ## Auto Counter
 


### PR DESCRIPTION
Adds **Tally Workout** — a first-party hosted MCP server for an iOS strength-training app — under a new **Health & Fitness** category (no existing category fit; happy to re-file if you'd prefer an existing one).

Criteria check:
- **MCP server:** Streamable HTTP at `https://mcp.tallyworkout.app/api/mcp`
- **Hosted/managed:** first-party hosted, nothing to run locally
- **Auth:** OAuth 2.1 (PKCE + dynamic client registration), one-click from claude.ai custom connectors (free tier works)
- **Actively maintained:** live in the shipping App Store app's connect flow
- **Documentation:** https://github.com/westvegh/tally-workout-mcp and https://tallyworkout.app/connect
- **Pricing:** free (bring your own Claude account)

Most fitness MCP servers are read-only wearable pipes; this one also **writes** — plan a training week in conversation and it lands in the app ready to log, with compare-and-swap writes so the model never overwrites what the human actually did in the gym.