### PR TITLE
Add DC Hub MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ _No entries yet_
 - **Offers:** Colorado crash data search, crash detail retrieval, personal injury attorney discovery, and AI-analyzed review intelligence
 - **Access:** Hosted remote endpoint at `https://crashstory-mcp-production.up.railway.app/mcp` with public install docs at `https://crashstory.com/mcp`
 
+#### [DC Hub](https://dchub.cloud/mcp)
+
+- **Offers:** Live data-center, power-grid, interconnection-queue, fiber, natural-gas & M&A intelligence for AI agents — DC Hub Power Index (311 markets), ISO grid telemetry & headroom, fiber routes, 21,000+ facilities across 170+ countries; 73 tools
+- **Access:** Remote endpoint at `https://dchub.cloud/mcp`. Anonymous 10 calls/day with no signup; a free key unlocks the full free tier; paid tiers for higher limits
+
 ### Developer Tools
 
 #### [Linear MCP](https://linear.app/docs/mcp)


### PR DESCRIPTION
Adds **DC Hub** — a remote, streamable-HTTP MCP server for AI agents (https://dchub.cloud/mcp).

Live data-center, power-grid, interconnection-queue, fiber, natural-gas & M&A intelligence — DC Hub Power Index across 311 markets, real-time ISO grid telemetry & headroom, fiber routes, 21,000+ facilities in 170+ countries; 73 tools. Anonymous 10 calls/day, no signup; free key unlocks the full free tier.

Repo: https://github.com/azmartone67/dchub-mcp-server · in the official MCP registry · CC-BY-4.0.