### PR TITLE
Add OpenChainBench remote MCP server to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [OpenChainBench](https://openchainbench.com)
+
+- **Offers:** Live, neutral crypto infrastructure benchmarks for agents. Public no-key RPC latency across 22 EVM chains plus Solana, oracle deviation, bridge quote fees, perp DEX all-in cost, prediction market resolution delay. Tools: `list_benchmarks`, `get_benchmark`, `query_prom`. Open methodology, CC BY 4.0 data
+- **Access:** Connect to `https://openchainbench.com/api/mcp/mcp` via Streamable HTTP; no authentication required; source at https://github.com/ChainBench/OpenChainBench
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
Adds OpenChainBench to Finance & Crypto. Endpoint https://openchainbench.com/api/mcp/mcp, Streamable HTTP, no auth. Tools: list_benchmarks, get_benchmark, query_prom. Coverage: public RPC latency (22 EVM chains + Solana), oracle deviation, bridge quote fees, perp DEX all-in cost, prediction market resolution delay. Homepage: https://openchainbench.com. Source: https://github.com/ChainBench/OpenChainBench. Data license CC BY 4.0. Also on the Official MCP Registry as io.github.Flotapponnier/openchainbench.