### PR TITLE
Add AgentServices — x402-paid crypto data MCP server (Finance & Crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ _No entries yet_
 - **Offers:** Public remote MCP server for real-time AI model momentum, `pick_model` routing across local aliases, leaderboard/feed reads, protocol state, wallet summaries, Jupiter quotes, and Solana market tooling
 - **Access:** Connect to `https://app.twzrd.xyz/api/mcp` via Streamable HTTP; manifest at `https://twzrd.xyz/.well-known/mcp-server.json`; public reads require no auth
 
+#### [AgentServices](https://github.com/vbkotecha/aiservices-api)
+
+- **Offers:** 54 services / 97 endpoints with 37 MCP tools: crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, news, social sentiment, on-chain analytics, correlation matrix, DeFi TVL, stablecoin flows, GitHub velocity, macro indicators, marketing intelligence, IP geolocation, URL metadata, web search, FX rates. 41 x402-paid endpoints ($0.01–$0.05/call, USDC on Base).
+- **Access:** Remote MCP server at `https://agentservices.to/mcp` (Streamable HTTP). Payment via x402 protocol — agents pay per call with USDC on Base, no API keys or registration. Official MCP Registry: `to.agentservices/agentservices` (v5.3.0).
+
 ### Gaming & Entertainment
 
 #### [SpaceMolt](https://www.spacemolt.com)


### PR DESCRIPTION
## AgentServices — x402-Paid Data APIs for AI Agents

**54 services / 97 endpoints with 37 MCP tools** covering crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, news, social sentiment, on-chain analytics, correlation matrix, DeFi TVL, stablecoin flows, GitHub velocity, macro indicators, marketing intelligence, IP geolocation, URL metadata, web search, and FX rates.

### Key Details

- **Remote MCP Server:** `https://agentservices.to/mcp` (Streamable HTTP)
- **Payment:** x402 protocol — agents pay per call with USDC on Base ($0.01–$0.05/call), no API keys or registration
- **Official MCP Registry:** `to.agentservices/agentservices` (v5.3.0, 3 versions published)
- **Repository:** https://github.com/vbkotecha/aiservices-api
- **Live API:** https://api.agentservices.to

### Why it fits

AgentServices is a production-ready, cloud-hosted MCP server in the Finance & Crypto category. It uses the x402 payment protocol (now under Linux Foundation governance) for agent-to-agent micropayments — no accounts, no API keys, the wallet is the identity.